### PR TITLE
Support lambdas without full src directory

### DIFF
--- a/src/hatch_aws/builder.py
+++ b/src/hatch_aws/builder.py
@@ -101,7 +101,7 @@ class AwsBuilder(BuilderInterface):
         build_dir = Path(self.config.directory) / aws_lambda.name
         if build_dir.exists():
             rmtree(build_dir)
-        build_dir.mkdir(parents=True)
+        build_dir.parent.mkdir(parents=True, exist_ok=True)
         lambda_dir = self.root / aws_lambda.code_uri / aws_lambda.module
         dist_lambda = build_dir / aws_lambda.module
         copytree(src=lambda_dir, dst=dist_lambda)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,3 +108,25 @@ def aws_lambda() -> AwsLambda:
         },
         name="MyLambdaFunc",
     )
+
+
+@pytest.fixture
+def limited_src_lambda() -> AwsLambda:
+    return AwsLambda(
+        default_code_uri=None,
+        default_handler=None,
+        resource={
+            "Properties": {
+                "CodeUri": "src/my_app/lambdas/lambda1",
+                "Handler": "main.app",
+                "Policies": "AWSLambdaExecute",
+                "Events": {
+                    "CreateThumbnailEvent": {
+                        "Type": "S3",
+                        "Properties": {"Bucket": "SrcBucket", "Events": "s3:ObjectCreated:*"},
+                    }
+                },
+            }
+        },
+        name="MyLambdaFunc",
+    )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -114,3 +114,14 @@ def test_build_lambda_with_pip_requirements(hatch, aws_lambda, deps):
     builder.build_lambda(aws_lambda=aws_lambda)
     dist_folder = Path(f"{builder.root}/.aws-sam/build/MyLambdaFunc")
     assert (dist_folder / "pytest").is_dir()
+
+
+@pytest.mark.slow
+def test_build_lambda_limited_src(hatch, limited_src_lambda):
+    builder = hatch()
+
+    builder.build_lambda(aws_lambda=limited_src_lambda)
+
+    dist_folder = Path(f"{builder.root}/.aws-sam/build/MyLambdaFunc")
+    files = os.listdir(dist_folder)
+    assert sorted(files) == ["db.py", "main.py"]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Hi, thanks for a great tool! Did run into a problem trying to adapt some existing repos to use hatch and this plugin though.

To limit the size of published lambdas, at work we often specify the `CodeUri` of the lambda to be a subset of the `src` directory. Trying that with this build system produced `FileExistsError`s from the call to `copytree` however.  

For example with your test setup, a `template.yml` of the following doesn't build using hatch but does using `sam build`:

```yaml
Resources:
    MyLambda1Func:
        Type: AWS::Serverless::Function
        Properties:
            CodeUri: src/my_app/lambdas/lambda1
            Handler: main.app
            # ...
```

Unfortunately the `dirs_exist_ok` flag for `copytree` was only introduced in python 3.8, but if we just ensure the parent build directory is present, then `copytree` doesn't complain.


<!--do not edit: pr-->
