### PR TITLE
fix: create requirements.txt parent dir before writing into

### DIFF
--- a/src/hatch_aws/builder.py
+++ b/src/hatch_aws/builder.py
@@ -55,6 +55,7 @@ class AwsBuilder(BuilderInterface):
         if not deps:
             return
         requirements_file = target / "requirements.txt"
+        requirements_file.parent.mkdir(exist_ok=True, parents=True)
         requirements_file.write_text(data="\n".join(deps), encoding="utf-8")
         check_call(
             [


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

Add `mkdir` for parent folder(s) of `requirements.txt`

Solves: https://github.com/aka-raccoon/hatch-aws/issues/9

<!--do not edit: pr-->
