### PR TITLE
Custom path to sam

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Following table contains available customization of builder behavior. You can fi
 | ------------ | ------- | -------------- | -------------------------------------------------------- |
 | `template`   | `str`   | `template.yml` | SAM template filename.                                   |
 | `use-sam`    | `bool`  | `false`        | Use only `sam build` command without any custom actions. |
+| `sam-exec`   | `str`   | `sam`          | Path to `sam` executable. Env var: `HATCH_SAM_EXEC`.     |
 | `sam-params` | `array` |                | Additional `sam build` args.                             |
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ test = ["coverage", "pytest", "pytest-cov", "pytest-mock", "tomli_w"]
 aws = "hatch_aws.hooks"
 
 [tool.hatch.build]
-exclude = [".github", "tests", ".editorconfig"]
 sources = ["src"]
+only-packages = true
 
 [project.urls]
 Documentation = "https://github.com/aka-raccoon/hatch-aws#readme"
@@ -55,19 +55,22 @@ features = ["dev", "test"]
 
 [tool.hatch.envs.default.scripts]
 check = [
-  "pylint src/",
-  "black --check --diff src/",
-  "isort --check-only --diff src/",
-  "mypy --install-types --non-interactive src/",
-  "bandit -r --configfile pyproject.toml src/",
+  "pylint $SRC",
+  "black --check --diff $SRC",
+  "isort --check-only --diff $SRC",
+  "mypy $SRC",
+  "bandit -r --configfile pyproject.toml $SRC",
 ]
-format = ["black src/", "isort src/"]
+fix = ["black $SRC", "isort $SRC"]
+
+[tool.hatch.envs.default.env-vars]
+SRC = "src/"
 
 [tool.hatch.envs.test]
 features = ["test"]
 
 [tool.hatch.envs.test.scripts]
-unit = "pytest --cov"
+unit = "pytest --cov {args}"
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.8", "3.9"]

--- a/src/hatch_aws/aws.py
+++ b/src/hatch_aws/aws.py
@@ -14,7 +14,8 @@ class AwsLambda:
 
 
 class Sam:  # pylint: disable=too-few-public-methods
-    def __init__(self, template: Path):
+    def __init__(self, sam_exec: str, template: Path):
+        self.exec = sam_exec
         self.template_path = template
         self.template = self._parse_sam_template()
         self.lambdas = self._get_aws_lambdas()
@@ -49,5 +50,9 @@ class Sam:  # pylint: disable=too-few-public-methods
         params.extend(def_params)
 
         return run(
-            ["sam", "build"] + params, text=True, encoding="utf-8", capture_output=True, check=False
+            [self.exec, "build"] + params,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=False,
         )

--- a/src/hatch_aws/builder.py
+++ b/src/hatch_aws/builder.py
@@ -79,7 +79,7 @@ class AwsBuilder(BuilderInterface):
     def build_standard(self, directory: str, **_build_data) -> str:
         self.config: AwsBuilderConfig
         try:
-            sam = Sam(template=self.config.template)
+            sam = Sam(sam_exec=self.config.sam_exec, template=self.config.template)
         except AttributeError:
             self.app.abort(
                 "Unsupported type for a 'CodeUri' or 'Handler'. Only string is supported."

--- a/src/hatch_aws/config.py
+++ b/src/hatch_aws/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import List, Optional
 
@@ -13,6 +14,7 @@ class AwsBuilderConfig(BuilderConfig):
         super().__init__(*args, **kwargs)
         self.__directory = None
         self.__template = None
+        self.__sam_exec = "sam"
         self.__use_sam = False
         self.__sam_params = None
 
@@ -49,6 +51,16 @@ class AwsBuilderConfig(BuilderConfig):
             self.__template = template
 
         return self.__template
+
+    @property
+    def sam_exec(self) -> str:
+        self.__sam_exec = self.target_config.get("sam_exec", self.__sam_exec)
+        self.__sam_exec = os.getenv("HATCH_SAM_EXEC", self.__sam_exec)
+        if not isinstance(self.__sam_exec, str):
+            raise TypeError(
+                f"Field `tool.hatch.build.targets.{self.plugin_name}.sam_exec` " "must be a string."
+            )
+        return self.__sam_exec
 
     @property
     def use_sam(self) -> bool:

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -4,7 +4,7 @@ from hatch_aws.aws import Sam
 
 
 def test_sam_init(asset):
-    sam = Sam(template=asset("sam-template.yml"))
+    sam = Sam(sam_exec="sam", template=asset("sam-template.yml"))
 
     lambda1, lambda2, lambda3, *other = sam.lambdas
 
@@ -22,4 +22,4 @@ def test_sam_init(asset):
 
 def test_unsupported_template(asset):
     with pytest.raises(AttributeError):
-        Sam(template=asset("sam-template-unsupported-handler.yml"))
+        Sam(sam_exec="sam", template=asset("sam-template-unsupported-handler.yml"))


### PR DESCRIPTION
Add option to set custom path to SAM cli via `sam-exec` config option or `HATCH_SAM_EXEC` env var.
